### PR TITLE
feat(toolchain): use prebuilt gawk via rules_multitool

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,4 +18,5 @@ register_toolchains("//awk/toolchains:gawk")
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.3", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.8.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,11 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "package_metadata", version = "0.0.2")
 bazel_dep(name = "platforms", version = "0.0.5")
-bazel_dep(name = "gawk", version = "5.3.2.bcr.1")
+bazel_dep(name = "rules_multitool", version = "1.11.1")
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")
 
 register_toolchains("//awk/toolchains:gawk")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ use_repo(multitool, "multitool")
 
 register_toolchains("//awk/toolchains:gawk")
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.19.3", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.2.2", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.8.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,8 @@ bazel_dep(name = "package_metadata", version = "0.0.2")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "gawk", version = "5.3.2.bcr.1")
 
+register_toolchains("//awk/toolchains:gawk")
+
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.3", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.8.0", dev_dependency = True)

--- a/awk.bzl
+++ b/awk.bzl
@@ -1,5 +1,7 @@
 "Re-export for syntax sugar load"
 
-load("//awk:awk.bzl", _awk = "awk")
+load("//awk:awk.bzl", _awk = "awk", _awk_toolchain = "awk_toolchain", _current_awk_toolchain = "current_awk_toolchain")
 
 awk = _awk
+awk_toolchain = _awk_toolchain
+current_awk_toolchain = _current_awk_toolchain

--- a/awk/BUILD
+++ b/awk/BUILD
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("//awk/private:toolchain.bzl", "current_awk_toolchain")
 
 current_awk_toolchain(

--- a/awk/BUILD
+++ b/awk/BUILD
@@ -1,4 +1,10 @@
 load("@aspect_bazel_lib//:bzl_library.bzl", "bzl_library")
+load("//awk/private:toolchain.bzl", "current_awk_toolchain")
+
+current_awk_toolchain(
+    name = "current_awk_toolchain",
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "awk",
@@ -6,6 +12,7 @@ bzl_library(
     visibility = ["//awk:__subpackages__"],
     deps = [
         "//awk/private:awk.bzl",
+        "//awk/private:toolchain",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//rules:write_file",
     ],

--- a/awk/awk.bzl
+++ b/awk/awk.bzl
@@ -3,11 +3,15 @@
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//awk/private:awk.bzl", _awk_lib = "awk_lib")
+load("//awk/private:toolchain.bzl", _awk_toolchain = "awk_toolchain", _current_awk_toolchain = "current_awk_toolchain")
+
+awk_toolchain = _awk_toolchain
+current_awk_toolchain = _current_awk_toolchain
 
 _awk_rule = rule(
     attrs = _awk_lib.attrs,
     implementation = _awk_lib.implementation,
-    # toolchains = ["@awk.bzl//awk/toolchain:type"],
+    toolchains = _awk_lib.toolchains,
 )
 
 def awk(name, src, program = None, progfile = None, out = None, **kwargs):

--- a/awk/private/BUILD
+++ b/awk/private/BUILD
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//awk:__subpackages__"])
 

--- a/awk/private/BUILD
+++ b/awk/private/BUILD
@@ -2,9 +2,17 @@ load("@aspect_bazel_lib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//awk:__subpackages__"])
 
-exports_files(["awk.bzl"])
+exports_files([
+    "awk.bzl",
+    "toolchain.bzl",
+])
 
 bzl_library(
     name = "awk",
     srcs = ["awk.bzl"],
+)
+
+bzl_library(
+    name = "toolchain",
+    srcs = ["toolchain.bzl"],
 )

--- a/awk/private/awk.bzl
+++ b/awk/private/awk.bzl
@@ -1,4 +1,5 @@
 "Implementation details of awk rule"
+
 _attrs = {
     "progfile": attr.label(allow_single_file = True),
     # FIXME: awk accepts a list
@@ -7,15 +8,14 @@ _attrs = {
     "args": attr.string_list(),
     "field_separator": attr.string(),
     "assign": attr.string_dict(),
-    # FIXME: use resolved toolchain
-    "_awk": attr.label(
-        default = "@gawk",
-        executable = True,
-        cfg = "exec",
-    ),
 }
 
+_TOOLCHAIN_TYPE = "//awk/toolchains:toolchain_type"
+
 def _awk_impl(ctx):
+    awk_info = ctx.toolchains[_TOOLCHAIN_TYPE].awk_info
+    awk = awk_info.awk
+
     args = ctx.actions.args()
     outs = [ctx.outputs.out]
     if ctx.attr.field_separator:
@@ -25,15 +25,16 @@ def _awk_impl(ctx):
     args.add_joined(["--file", ctx.file.progfile], join_with = "=")
     args.add_all(ctx.files.src)
     ctx.actions.run_shell(
-        command = "{} $@ >{}".format(ctx.executable._awk.path, ctx.outputs.out.path),
+        command = "{} $@ >{}".format(awk.executable.path, ctx.outputs.out.path),
         arguments = [args],
         inputs = ctx.files.src + [ctx.file.progfile],
         outputs = outs,
-        tools = [ctx.executable._awk],
+        tools = [awk],
     )
     return [DefaultInfo(files = depset(outs))]
 
 awk_lib = struct(
     attrs = _attrs,
     implementation = _awk_impl,
+    toolchains = [_TOOLCHAIN_TYPE],
 )

--- a/awk/private/toolchain.bzl
+++ b/awk/private/toolchain.bzl
@@ -1,0 +1,44 @@
+"Toolchain definitions for awk"
+
+AwkInfo = provider(
+    doc = "Information about an awk executable",
+    fields = {
+        "awk": "A FilesToRunProvider for the awk binary",
+    },
+)
+
+def _awk_toolchain_impl(ctx):
+    return [platform_common.ToolchainInfo(
+        awk_info = AwkInfo(awk = ctx.attr.awk[DefaultInfo].files_to_run),
+    )]
+
+awk_toolchain = rule(
+    implementation = _awk_toolchain_impl,
+    attrs = {
+        "awk": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def _current_awk_toolchain_impl(ctx):
+    toolchain = ctx.toolchains["//awk/toolchains:toolchain_type"]
+    awk = toolchain.awk_info.awk
+
+    default_info = DefaultInfo(
+        files = depset([awk.executable]),
+        runfiles = ctx.runfiles(files = [awk.executable]),
+    )
+
+    template_variable_info = platform_common.TemplateVariableInfo({
+        "AWK": awk.executable.path,
+    })
+
+    return [default_info, template_variable_info]
+
+current_awk_toolchain = rule(
+    implementation = _current_awk_toolchain_impl,
+    toolchains = ["//awk/toolchains:toolchain_type"],
+)

--- a/awk/tests/BUILD
+++ b/awk/tests/BUILD
@@ -1,3 +1,39 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(":tests.bzl", "awk_test_suite")
 
 awk_test_suite(name = "tests")
+
+# Test that $(AWK) is usable from a genrule via current_awk_toolchain.
+write_file(
+    name = "genrule_input",
+    out = "genrule_input.txt",
+    content = [
+        "hello world",
+        "foo bar",
+    ],
+)
+
+genrule(
+    name = "genrule_awk",
+    srcs = ["genrule_input.txt"],
+    outs = ["genrule_awk.txt"],
+    cmd = "$(AWK) '{print $$2}' $< > $@",
+    toolchains = ["//awk:current_awk_toolchain"],
+)
+
+write_file(
+    name = "genrule_expected",
+    out = "genrule_expected.txt",
+    content = [
+        "world",
+        "bar",
+        "",
+    ],
+)
+
+diff_test(
+    name = "genrule_awk_test",
+    file1 = "genrule_awk.txt",
+    file2 = "genrule_expected.txt",
+)

--- a/awk/tests/BUILD
+++ b/awk/tests/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(":tests.bzl", "awk_test_suite")
 
 awk_test_suite(name = "tests")
@@ -36,4 +37,12 @@ diff_test(
     name = "genrule_awk_test",
     file1 = "genrule_awk.txt",
     file2 = "genrule_expected.txt",
+)
+
+# Test that the resolved awk binary comes from a multitool-managed repository.
+sh_test(
+    name = "multitool_origin_test",
+    srcs = ["multitool_origin_test.sh"],
+    args = ["$(location //awk:current_awk_toolchain)"],
+    data = ["//awk:current_awk_toolchain"],
 )

--- a/awk/tests/multitool_origin_test.sh
+++ b/awk/tests/multitool_origin_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+awk_path="$1"
+
+# The resolved path should come from a multitool-managed repository.
+if [[ "$awk_path" == *"multitool"* ]]; then
+  echo "PASS: awk binary path contains 'multitool': $awk_path"
+  exit 0
+else
+  echo "FAIL: awk binary path does not contain 'multitool': $awk_path"
+  exit 1
+fi

--- a/awk/toolchains/BUILD
+++ b/awk/toolchains/BUILD
@@ -7,7 +7,7 @@ toolchain_type(
 
 awk_toolchain(
     name = "gawk_toolchain_impl",
-    awk = "@gawk",
+    awk = "@multitool//tools/gawk",
     visibility = ["//visibility:public"],
 )
 

--- a/awk/toolchains/BUILD
+++ b/awk/toolchains/BUILD
@@ -1,0 +1,19 @@
+load("//awk/private:toolchain.bzl", "awk_toolchain")
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+awk_toolchain(
+    name = "gawk_toolchain_impl",
+    awk = "@gawk",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "gawk",
+    toolchain = ":gawk_toolchain_impl",
+    toolchain_type = "//awk/toolchains:toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
+load("@bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@awk.bzl", "awk")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "awk.bzl", version = "0.0.0", dev_dependency = True)
-bazel_dep(name = "aspect_bazel_lib", version = "2.17.1", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.2.2", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
 
 local_path_override(

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/bazel-contrib/rules_multitool/main/lockfile.schema.json",
+  "gawk": {
+    "binaries": [
+      {
+        "kind": "file",
+        "url": "https://github.com/plobsing/gawk-prebuilt/releases/download/v5.3.2%2Beaa1d484/gawk_darwin_amd64",
+        "sha256": "738a96e5cf7ab4235838854985c573ca6ebafca0af40372a381daa199b7d62f6",
+        "os": "macos",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/plobsing/gawk-prebuilt/releases/download/v5.3.2%2Beaa1d484/gawk_darwin_arm64",
+        "sha256": "28206d7625cf6008ddb576f5a56953151034b69021c3171e9718e6634bdda54c",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/plobsing/gawk-prebuilt/releases/download/v5.3.2%2Beaa1d484/gawk_linux_amd64",
+        "sha256": "20e6fd3ea50a69ddb4d574a76a718c244c3b9f3225057e3e6136ab6a96bfb2b9",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/plobsing/gawk-prebuilt/releases/download/v5.3.2%2Beaa1d484/gawk_linux_arm64",
+        "sha256": "81344c183b39b29e24bdb0e636c930521534457372cc3b0a4efe3f540b9d573d",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/plobsing/gawk-prebuilt/releases/download/v5.3.2%2Beaa1d484/gawk_windows_amd64.exe",
+        "sha256": "1a5f67670888e17398d6acb1ad44ddcac134a6ba3f58acf67563ea8417ba31e1",
+        "os": "windows",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/plobsing/gawk-prebuilt/releases/download/v5.3.2%2Beaa1d484/gawk_windows_arm64.exe",
+        "sha256": "7c474f93c848b700de5eaf5cd74177b18d53698b0b484c5b03be6b05db73dc48",
+        "os": "windows",
+        "cpu": "arm64"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the source-built `@gawk` (BCR `cc_binary`) with prebuilt binaries from [plobsing/gawk-prebuilt](https://github.com/plobsing/gawk-prebuilt) v5.3.2
- Uses [rules_multitool](https://github.com/bazel-contrib/rules_multitool) to fetch platform-appropriate prebuilt binaries
- Eliminates the need for a CC toolchain and avoids gcc warning spam
- Prebuilt binaries available for: linux (amd64/arm64), macOS (amd64/arm64), Windows (amd64/arm64)
- Includes the awk toolchain type from #15 as a prerequisite

Closes #4

**Note:** This PR depends on the toolchain type introduced in #15. The first commit is cherry-picked from that branch.

## Test plan

- [x] `bazel clean && bazel test //awk/tests/...` passes — confirms prebuilt binary works with no CC toolchain
- [x] `bazel build //awk/...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)